### PR TITLE
Remove host prefixes in source path to allow make

### DIFF
--- a/recipes-connectivity/nrc-cli/nrc-cli_1.34.bb
+++ b/recipes-connectivity/nrc-cli/nrc-cli_1.34.bb
@@ -6,13 +6,17 @@ SRCBRANCH = "nrc-dkms-v1.2.2-rc1"
 SRCREV = "d7a3b5370fe4b0fbf8c9e296d43e7813d8347ae2"
 SRC_URI = "git://github.com/teledatics/nrc7394_sw_pkg.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${WORKDIR}/git/package/host/src/cli_app"
+S = "${WORKDIR}/git/package/src/cli_app"
 
 RPROVIDES_${PN} += "${PN}"
 
 FILES:${PN} += "${bindir}/cli_app"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
+
+do_compile() {
+    oe_runmake
+}
 
 do_install() {
     install -d ${D}${bindir}

--- a/recipes-kernel/nrc-mod/kernel-module-nrc-mod_1.34.bb
+++ b/recipes-kernel/nrc-mod/kernel-module-nrc-mod_1.34.bb
@@ -9,7 +9,7 @@ SRCBRANCH = "nrc-dkms-v1.2.2-rc1"
 SRCREV = "d7a3b5370fe4b0fbf8c9e296d43e7813d8347ae2"
 SRC_URI = "git://github.com/teledatics/nrc7394_sw_pkg.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${WORKDIR}/git/package/host/src/nrc"
+S = "${WORKDIR}/git/package/src/nrc"
 
 EXTRA_OEMAKE = "KDIR=${STAGING_KERNEL_DIR}"
 


### PR DESCRIPTION
# Problem
nrc-cli and nrc kernel module recipes do not build due to wrong S directory setting. This should change. Plus supply a compile command where necessary.

# Solution
1. Update S dirs for cli_app and nrc kernel module.
2. Add do_compile() for cli_app

# Testing
Tested by building nrc-cli and kernel modules recipes into Aigen's image.