### PR TITLE
Update recipes and add FIXMEs for investigation

### DIFF
--- a/recipes-kernel/nrc-mod/files/nrc_gpiono.sh
+++ b/recipes-kernel/nrc-mod/files/nrc_gpiono.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # Teledatics TD-XPAH gpio number tool
-
 GPIO=$(for i in $(ls /sys/bus/usb/devices/); do for j in $(ls /sys/bus/usb/devices/$i/); do if [ "$j" == "spi-ft232h.0" ]; then echo $(basename /sys/bus/usb/devices/$i/gpiochip* | sed 's/[^0-9]*//g'); fi; done; done)
+
+# TODO: is this logic correct for imx.8mp?
 GPIO=$(echo "($GPIO - 1) * 32" | bc)
 GPIO_NO=${GPIO:--1}
-# FIXME - gpio sysfs removed from kernel, hardcode for now, fix later
-GPIO_NO=492
+
 echo ${GPIO_NO}
+

--- a/recipes-kernel/nrc-mod/files/nrc_load_module.sh
+++ b/recipes-kernel/nrc-mod/files/nrc_load_module.sh
@@ -4,7 +4,7 @@
 
 SPI_BUS_NO=`nrc_busno.sh`
 SPI_GPIO_NO=`nrc_gpiono.sh`
-MOD_PATH="/lib/modules/`uname -r`/updates/dkms"
+MOD_PATH="/lib/modules/`uname -r`/extra"
 MOD_NAME="nrc"
 MOD_PATH_NAME=`ls ${MOD_PATH}/${MOD_NAME}*`
 

--- a/recipes-kernel/nrc-mod/kernel-module-nrc-mod_1.34.bb
+++ b/recipes-kernel/nrc-mod/kernel-module-nrc-mod_1.34.bb
@@ -19,6 +19,9 @@ do_install() {
 
 RPROVIDES_${PN} += "${PN}"
 
+# TODO: evaluate config needs. This line is needed to avoid do_configure() failures.
+do_configure[noexec] = "1"
+
 # add helper scripts and modprobe conf file
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += "file://nrc.conf"


### PR DESCRIPTION
## Problem
Kernel module fails to build. Kernel module location and GPIO derivation scripts need logic update.

## Solution
1. Add no-config to kernel mod.
2. Update scripts with FIXMEs.

## Testing
Build only. Kernel module does not load.